### PR TITLE
whl: Parse requirements from METADATA files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,6 +85,15 @@ http_file(
 )
 
 http_file(
+    name = "wheel_0_31_0_whl",
+    sha256 = "9cdc8ab2cc9c3c2e2727a4b67c22881dbb0e1c503d592992594c5e131c867107",
+    # From https://pypi.python.org/pypi/wheel/0.31.0
+    url = ("https://pypi.python.org/packages/1b/d2/" +
+           "22cde5ea9af055f81814f9f2545f5ed8a053eb749c08d186b369959189a8/" +
+           "wheel-0.31.0-py2.py3-none-any.whl"),
+)
+
+http_file(
     name = "mock_whl",
     sha256 = "5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
     # From https://pypi.python.org/pypi/mock

--- a/rules_python/BUILD
+++ b/rules_python/BUILD
@@ -35,6 +35,7 @@ py_test(
         "@google_cloud_language_whl//file",
         "@grpc_whl//file",
         "@mock_whl//file",
+        "@wheel_0_31_0_whl//file",
     ],
     deps = [
         ":whl",

--- a/rules_python/whl_test.py
+++ b/rules_python/whl_test.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 from mock import patch
+from pkg_resources._vendor.packaging import markers
 
 from rules_python import whl
 
@@ -54,7 +55,58 @@ class WheelTest(unittest.TestCase):
     self.assertEqual(wheel.distribution(), 'futures')
     self.assertEqual(wheel.version(), '2.2.0')
     self.assertEqual(set(wheel.dependencies()), set())
+    self.assertEqual(set(wheel.extras()), set())
     self.assertEqual('pypi__futures_2_2_0', wheel.repository_name())
+
+  def test_whl_with_METADATA_and_extras_file(self):
+    td = TestData('wheel_0_31_0_whl/file/wheel-0.31.0-py2.py3-none-any.whl')
+    wheel = whl.Wheel(td)
+    self.assertEqual(wheel.name(), 'wheel')
+    self.assertEqual(wheel.distribution(), 'wheel')
+    self.assertEqual(wheel.version(), '0.31.0')
+    self.assertEqual(set(wheel.dependencies()), set())
+    self.assertEqual(set(wheel.extras()), set(['test', 'signatures', 'faster-signatures']))
+    self.assertEqual('pypi__wheel_0_31_0', wheel.repository_name())
+
+    self.assertEqual(set(['keyring', 'keyrings.alt', 'pyxdg']), set(wheel.dependencies(extra='signatures')))
+    self.assertEqual(set(['ed25519ll']), set(wheel.dependencies(extra='faster-signatures')))
+    self.assertEqual(set(['pytest', 'pytest-cov']), set(wheel.dependencies(extra='test')))
+
+  def test_split_environment(self):
+    with self.assertRaises(markers.InvalidMarker):
+      whl.split_extra_from_environment_marker('')
+
+    extra, environment = whl.split_extra_from_environment_marker('extra == "foo"')
+    self.assertEqual('foo', extra)
+    self.assertEqual('', environment)
+
+    # from ipython
+    env = 'sys_platform != "win32"'
+    extra, environment = whl.split_extra_from_environment_marker(env)
+    self.assertEqual('', extra)
+    self.assertEqual(env, environment)
+
+    # from mock
+    env = '(python_version<"3.3" and python_version>="3") and extra == \'docs\''
+    extra, environment = whl.split_extra_from_environment_marker(env)
+    self.assertEqual('docs', extra)
+    self.assertEqual('(python_version < "3.3" and python_version >= "3")', environment)
+
+    # from requests
+    env = 'sys_platform == "win32" and (python_version == "2.7" or python_version == "2.6") and extra == \'socks\''
+    extra, environment = whl.split_extra_from_environment_marker(env)
+    self.assertEqual('socks', extra)
+    self.assertEqual('sys_platform == "win32" and (python_version == "2.7" or python_version == "2.6")', environment)
+
+    # fake to ensure ands are remove correctly
+    env = 'sys_platform == "win32" and extra == \'socks\' and python_version == "2.7"'
+    extra, environment = whl.split_extra_from_environment_marker(env)
+    self.assertEqual('socks', extra)
+    self.assertEqual('sys_platform == "win32" and python_version == "2.7"', environment)
+    env = 'extra == \'socks\' and python_version == "2.7"'
+    extra, environment = whl.split_extra_from_environment_marker(env)
+    self.assertEqual('socks', extra)
+    self.assertEqual('python_version == "2.7"', environment)
 
   @patch('platform.python_version', return_value='2.7.13')
   def test_mock_whl(self, *args):


### PR DESCRIPTION
Some wheels only include METADATA files (examples: wheel 0.31.0,
tenacity 4.10.0). Previously whl did not parse the requirement
sections. Add code to parse these sections.

The most complicated part is parsing out the extra == 'something'
clauses from the boolean expression. Use the same expression parser
used by pkg_resources.evaluate_marker which is already used by this
code to find those clauses and produce a version with them removed.